### PR TITLE
Update to most current version of BTP TF provider

### DIFF
--- a/examples/btp-entitlements-sample/main.tf
+++ b/examples/btp-entitlements-sample/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     btp = {
       source  = "sap/btp"
-      version = "0.2.0-beta2"
+      version = "0.4.0-beta1"
     }
   }
 }


### PR DESCRIPTION
This PR updates the Terraform provider for SAP BTP. During the beta phase this needs to happen with every new release.

Once the TF provider will be available for productive usage, this won't be necessary anymore.